### PR TITLE
feat(mails):implement functionality to view all unread received mails

### DIFF
--- a/server/controllers/message.js
+++ b/server/controllers/message.js
@@ -51,4 +51,26 @@ export class MessageController {
       data: receivedMessages
     });
   }
+
+  /**
+       * User can fetch all unread received emails on the application
+       * @static
+       * @param {object} req - The request object
+       * @param {object} res - The response object
+       * @return {object} JSON object representing success
+       * @memeberof MessageController
+       */
+  static fetchAllUnreadMails(req, res) {
+    const unreadMails = receivedMessages.filter(message => message.status === 'unread');
+    if (unreadMails.length === 0) {
+      return res.status(404).json({
+        status: 404,
+        error: 'You have no unread emails at this time'
+      });
+    }
+    return res.status(200).json({
+      status: 200,
+      data: unreadMails
+    });
+  }
 }

--- a/server/routes/message.js
+++ b/server/routes/message.js
@@ -2,10 +2,11 @@ import express from 'express';
 import { MessageController } from '../controllers';
 import { messageValidator } from '../middlewares';
 
-const { postMessage, receiveAllMails } = MessageController;
+const { postMessage, receiveAllMails, fetchAllUnreadMails } = MessageController;
 
 
 export const messageRouter = express.Router();
 
 messageRouter.post('/messages', messageValidator, postMessage);
 messageRouter.get('/messages', receiveAllMails);
+messageRouter.get('/messages/unread', fetchAllUnreadMails);

--- a/server/tests/bmessage.test.js
+++ b/server/tests/bmessage.test.js
@@ -86,5 +86,18 @@ describe('Test for Message routes', () => {
           done();
         });
     });
+    it('Should return 200 status code and fetch all received UNREAD MAILS in the db', (done) => {
+      const messages = receivedMessages.length;
+      chai.request(app)
+        .get('/api/v1/messages/unread')
+        .end((err, res) => {
+          res.should.have.status(200);
+          res.body.should.be.an('object');
+          expect(res.body.status).to.equal(200);
+          expect(res.body.data).to.be.a('array');
+          expect(receivedMessages).to.have.length(messages);
+          done();
+        });
+    });
   });
 });


### PR DESCRIPTION
#### What does this PR do?

Ensure that methods works according to specs
Ensure that use can get all unread received mails if found in the db
Write test for endpoint



#### Description of Task to be completed?

- Implement get all unread mails endpoint



#### How should this be manually tested?

- Further instructions will be on the readMe



#### Any background context you want to provide?

- None



#### What are the relevant pivotal tracker stories?

- PT Story link - (format - `[#164365731](https://www.pivotaltracker.com/story/show/#164365731)`)


[Delivers #164365731]